### PR TITLE
fix error and improve comparaison for PR alerts

### DIFF
--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -459,7 +459,11 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                     if (e != null && e.isAddedPath) {
                         val leaves = map[e.path.parentPath.lastPathComponent.toString()]
                         if (!leaves.isNullOrEmpty()) {
-                            val leaf = leaves.first { it.address == e.path.lastPathComponent.toString() }
+                            val leaf = try {
+                                leaves.first { it.address == ((e.path.lastPathComponent as DefaultMutableTreeNode).userObject as Leaf).address }
+                            } catch (e: Exception) {
+                                leaves.first()
+                            }
 
                             val githubAlertUrl = leaf.githubAlertUrl
                                 .replace("api.", "")
@@ -588,7 +592,8 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                     val mainResults: List<Result> = sarifMainBranch.flatMap { it.runs?.get(0)?.results ?: emptyList() }
 
                     for (currentResult in results) {
-                        if (mainResults.none { it.ruleId == currentResult.ruleId && it.message.text == currentResult.message.text }) {
+                        if (mainResults.none { it.ruleId == currentResult.ruleId
+                                    && ("${currentResult.locations[0].physicalLocation.artifactLocation.uri}:${currentResult.locations[0].physicalLocation.region.startLine}" == "${it.locations[0].physicalLocation.artifactLocation.uri}:${it.locations[0].physicalLocation.region.startLine}") }) {
                             resultsToDisplay.add(currentResult)
                         }
                     }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the logic and error handling in the `SarifViewerWindowFactory` class in the `sarifviewer/toolWindow/SarifViewerWindowFactory.kt` file. The two main changes involve refining the method of fetching the first leaf node and improving the condition for adding results to `resultsToDisplay`.

Here are the key changes:

* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL462-R466): Updated the logic for fetching the first leaf node. Instead of directly accessing the `address` property of the `lastPathComponent`, the update now tries to cast `lastPathComponent` to `DefaultMutableTreeNode` and then to `Leaf` before accessing the `address`. If any exception occurs during this process, the first leaf node from `leaves` is returned. This change enhances error handling and prevents potential crashes due to incorrect type casting.

* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL591-R596): Improved the condition for adding `currentResult` to `resultsToDisplay`. The updated condition checks not only for a match in `ruleId` but also for a match in the `uri` and `startLine` of the `physicalLocation`. This change ensures that only unique and relevant results are added to `resultsToDisplay`.