### PR TITLE
feat: navigate to column on top of line

### DIFF
--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/services/SarifService.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/services/SarifService.kt
@@ -100,8 +100,8 @@ class SarifService {
         val additionalProperties = result.properties?.additionalProperties ?: mapOf()
         val element = Leaf(
             leafName = result.message.text ?: "",
-            address = "${result.locations[0].physicalLocation.artifactLocation.uri}:${result.locations[0].physicalLocation.region.startLine}",
-            steps = result.codeFlows?.get(0)?.threadFlows?.get(0)?.locations?.map { "${it.location.physicalLocation.artifactLocation.uri}:${it.location.physicalLocation.region.startLine}" }
+            address = "${result.locations[0].physicalLocation.artifactLocation.uri}:${result.locations[0].physicalLocation.region.startLine ?: 0}:${result.locations[0].physicalLocation.region.startColumn ?: 0}",
+            steps = result.codeFlows?.get(0)?.threadFlows?.get(0)?.locations?.map { "${it.location.physicalLocation.artifactLocation.uri}:${it.location.physicalLocation.region.startLine}:${it.location.physicalLocation.region.startColumn}" }
                 ?: listOf(),
             location = result.locations[0].physicalLocation.artifactLocation.uri,
             ruleId = result.ruleId,

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -538,16 +538,17 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                                 override fun mouseClicked(e: MouseEvent) {
                                     val row = tableInfos.rowAtPoint(e.point)
                                     val path = currentLeaf!!.steps[row].split(":")
-                                    openFile(project, path[0], path[1].toInt())
+                                    openFile(project, path[0], path[1].toInt(), path[2].toInt())
                                 }
                             })
 
                             details.isVisible = true
+                            val addr = currentLeaf!!.address.split(":")
                             openFile(
                                 project,
                                 currentLeaf!!.location,
-                                currentLeaf!!.address.split(":")[1].toInt(),
-                                0,
+                                addr[1].toInt(),
+                                addr[2].toInt(),
                                 currentLeaf!!.level,
                                 currentLeaf!!.ruleId,
                                 currentLeaf!!.ruleDescription
@@ -595,7 +596,7 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                         project,
                         virtualFile,
                         lineNumber - 1,
-                        columnNumber
+                        columnNumber - 1
                     ),
                     true // request focus to editor
                 )


### PR DESCRIPTION
This pull request primarily includes changes to the `SarifService` and `SarifViewerWindowFactory` classes in the `sarifviewer` package to enhance the handling of source code locations. The changes involve the addition of column information to the `Leaf` class and the `openFile` method, and an adjustment to the column number in the `openFile` method.

Here are the key changes:

Changes to the `SarifService` class:
* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/services/SarifService.kt`](diffhunk://#diff-cb3fe2ef7ae731df7e5f23818367a34e43310aed8bf3e094ed5ec11e9afc976cL103-R104): The `Leaf` object now includes column information in the `address` and `steps` fields. Previously, these fields only contained the URI and start line. Now, they also include the start column, providing more precise location information. If the start column is not available, it defaults to 0.

Changes to the `SarifViewerWindowFactory` class:
* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL541-R551): The `openFile` method now accepts an additional parameter for the column number. This change is reflected where the method is invoked, such as in the `mouseClicked` event and when opening a file. The column number passed to `openFile` is now extracted from the `address` field of the `currentLeaf` object.
* [`src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt`](diffhunk://#diff-288180ac0a3fecc78b7bddb4690cf8f8b1be6d3fea94b5da8f00cfb804dcc2daL598-R599): The column number passed to the `navigate` method of the `FileEditorManager` instance is reduced by 1 to correctly align with the zero-based indexing of columns in the editor.