### PR TITLE
Feature/show hide token in settings

### DIFF
--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt
@@ -80,7 +80,7 @@ class SettingComponent {
     }
 
     fun getGhTokenText(): String {
-        return if (toggleButton.isSelected) {
+        return if (isGhTokenVisible) {
             ghTokenTextField.text
         } else {
             ghTokenPasswordField.text
@@ -88,11 +88,8 @@ class SettingComponent {
     }
 
     fun setGhTokenText(newText: String) {
-        if (toggleButton.isSelected) {
-            ghTokenTextField.text = newText
-        } else {
-            ghTokenPasswordField.text = newText
-        }
+        ghTokenTextField.text = newText
+        ghTokenPasswordField.text = newText
     }
 
     fun getGhesHostnameText(): String {
@@ -100,7 +97,7 @@ class SettingComponent {
     }
 
     fun getGhesTokenText(): String {
-        return if (toggleButton.isSelected) {
+        return if (isGhTokenVisible) {
             ghesTokenTextField.text
         } else {
             ghesTokenPasswordField.text
@@ -112,11 +109,8 @@ class SettingComponent {
     }
 
     fun setGhesTokenText(newText: String) {
-        if (toggleButton.isSelected) {
-            ghesTokenTextField.text = newText
-        } else {
-            ghesTokenPasswordField.text = newText
-        }
+        ghesTokenTextField.text = newText
+        ghesTokenPasswordField.text = newText
     }
 }
 

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt
@@ -4,24 +4,66 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.JTextField
+import javax.swing.JToggleButton
 
 
 class SettingComponent {
     private var myMainPanel: JPanel? = null
-    private val ghTokenText = JBPasswordField()
+    private var ghTokenTextField: JTextField =JBTextField()
+    private var ghTokenPasswordField: JTextField = JBPasswordField()
     private val ghesHostnameText = JBTextField()
-    private val ghesTokenText = JBPasswordField()
+    private var ghesTokenTextField: JTextField  = JBTextField()
+    private var ghesTokenPasswordField: JTextField  = JBPasswordField()
+    private val toggleButton = JToggleButton("Show/Hide PAT")
+
+    private var isGhTokenVisible: Boolean = false
 
     init {
+
+        ghTokenTextField.isVisible = isGhTokenVisible
+        ghesTokenTextField.isVisible = isGhTokenVisible
         myMainPanel = FormBuilder.createFormBuilder()
-                .addLabeledComponent(JBLabel("GitHub.com PAT "), ghTokenText, 1, false)
-                .addSeparator()
-                .addLabeledComponent(JBLabel("GHES Hostname"), ghesHostnameText, 2, false)
-                .addLabeledComponent(JBLabel("GHES PAT"), ghesTokenText, 3, false)
-                .addComponentFillVertically(JPanel(), 0)
-                .getPanel()
+            .addComponent(JBLabel("GitHub.com PAT "))
+            .addComponent(ghTokenTextField)
+            .addComponent(ghTokenPasswordField)
+            .addSeparator(48)
+            .addComponent(JBLabel("GHES Hostname "))
+            .addComponent(ghesHostnameText)
+            .addComponent(JBLabel("GHES PAT "))
+            .addComponent(ghesTokenTextField)
+            .addComponent(ghesTokenPasswordField)
+            .addComponentFillVertically(JPanel(), 0)
+            .addSeparator()
+            .addLabeledComponent("", toggleButton, 1, false)
+            .panel
+
+        toggleButton.addActionListener {
+            isGhTokenVisible = !isGhTokenVisible
+            if (isGhTokenVisible) {
+                ghTokenTextField.text = ghTokenPasswordField.text
+                ghTokenTextField.isVisible = true
+                ghTokenPasswordField.isVisible = false
+
+                ghesTokenTextField.text = ghesTokenPasswordField.text
+                ghesTokenTextField.isVisible = true
+                ghesTokenPasswordField.isVisible = false
+            } else {
+                ghTokenPasswordField.text = ghTokenTextField.text
+                ghTokenTextField.isVisible = false
+                ghTokenPasswordField.isVisible = true
+
+                ghesTokenPasswordField.text = ghesTokenTextField.text
+                ghesTokenTextField.isVisible = false
+                ghesTokenPasswordField.isVisible = true
+            }
+            myMainPanel!!.revalidate() // Notify the layout manager
+            myMainPanel!!.repaint() // Redraw the components
+        }
     }
 
 
@@ -30,15 +72,27 @@ class SettingComponent {
     }
 
     fun getPreferredFocusedComponent(): JComponent {
-        return ghTokenText
+        return if (toggleButton.isSelected) {
+            ghTokenTextField
+        } else {
+            ghTokenPasswordField
+        }
     }
 
     fun getGhTokenText(): String {
-        return ghTokenText.text
+        return if (toggleButton.isSelected) {
+            ghTokenTextField.text
+        } else {
+            ghTokenPasswordField.text
+        }
     }
 
     fun setGhTokenText(newText: String) {
-        ghTokenText.text = newText
+        if (toggleButton.isSelected) {
+            ghTokenTextField.text = newText
+        } else {
+            ghTokenPasswordField.text = newText
+        }
     }
 
     fun getGhesHostnameText(): String {
@@ -46,7 +100,11 @@ class SettingComponent {
     }
 
     fun getGhesTokenText(): String {
-        return ghesTokenText.text
+        return if (toggleButton.isSelected) {
+            ghesTokenTextField.text
+        } else {
+            ghesTokenPasswordField.text
+        }
     }
 
     fun setGhesHostnameText(newText: String) {
@@ -54,6 +112,13 @@ class SettingComponent {
     }
 
     fun setGhesTokenText(newText: String) {
-        ghesTokenText.text = newText
+        if (toggleButton.isSelected) {
+            ghesTokenTextField.text = newText
+        } else {
+            ghesTokenPasswordField.text = newText
+        }
     }
 }
+
+
+


### PR DESCRIPTION
This pull request in `src/main/kotlin/com/github/adrienpessu/sarifviewer/configurable/SettingComponent.kt` introduces changes to enhance the user interface and improve security. The most significant changes include introducing a toggle button to show or hide Personal Access Tokens (PAT), replacing `JBPasswordField` with `JTextField` and `JBPasswordField` for better control over visibility, and updating methods to support these changes.