### PR TITLE
Added a toggle Action Button to allow the user to switch the labelling of warnings in the plugin

### DIFF
--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/RuleIdorDescriptionAction.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/actions/RuleIdorDescriptionAction.kt
@@ -1,0 +1,14 @@
+package com.github.adrienpessu.sarifviewer.actions
+
+import com.github.adrienpessu.sarifviewer.toolWindow.SarifViewerWindowFactory
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class RuleIDorDescriptionAction : AnAction("Toggle Rule ID or Description") {
+
+    var myToolWindow: SarifViewerWindowFactory.MyToolWindow? = null
+
+    override fun actionPerformed(e: AnActionEvent) {
+        myToolWindow?.toggleRuleIdOrDescription()
+    }
+}

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/models/View.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/models/View.kt
@@ -5,7 +5,8 @@ data class View(
     val value: String = ""
 ) {
     override fun toString() = value
-
+    var ruleIdToggle: Boolean = true
+    
     companion object {
         val RULE = View("rules", "View by rules")
         val LOCATION = View("location", "View by location")

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/services/SarifService.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/services/SarifService.kt
@@ -56,7 +56,11 @@ class SarifService {
                     sarif.runs.forEach { run ->
                         run?.results?.forEach { result ->
                             val element = leaf(result)
-                            val key = result.rule?.id ?: result.correlationGuid?.toString() ?: result.message.text
+                            var key = "init"
+                            if (view.ruleIdToggle)
+                                key = result.rule?.id ?: result.correlationGuid?.toString() ?: result.message.text
+                            else
+                                 key = result.rule?.id ?: result.correlationGuid?.toString() ?: result.ruleId
                             if (map.containsKey(key)) {
                                 map[key]?.add(element)
                             } else {
@@ -74,6 +78,8 @@ class SarifService {
                 try {
                     sarif.runs.forEach { run ->
                         run?.results?.forEach { result ->
+                            if (view.ruleIdToggle)
+                                result.message.text = result.ruleId
                             val element = leaf(result)
                             val key = result.locations[0].physicalLocation.artifactLocation.uri
                             if (map.containsKey(key)) {

--- a/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
+++ b/src/main/kotlin/com/github/adrienpessu/sarifviewer/toolWindow/SarifViewerWindowFactory.kt
@@ -5,6 +5,7 @@ import com.contrastsecurity.sarif.SarifSchema210
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.adrienpessu.sarifviewer.actions.OpenLocalAction
 import com.github.adrienpessu.sarifviewer.actions.RefreshAction
+import com.github.adrienpessu.sarifviewer.actions.RuleIDorDescriptionAction
 import com.github.adrienpessu.sarifviewer.configurable.Settings
 import com.github.adrienpessu.sarifviewer.configurable.SettingsState
 import com.github.adrienpessu.sarifviewer.exception.SarifViewerException
@@ -82,11 +83,14 @@ class SarifViewerWindowFactory : ToolWindowFactory {
         init {
             val actionManager = ActionManager.getInstance()
 
+            val toggleRuleIdOrDescriptionAction = actionManager.getAction("RuleIDorDescriptionAction")
+            (toggleRuleIdOrDescriptionAction as RuleIDorDescriptionAction).myToolWindow = this
             val openLocalFileAction = actionManager.getAction("OpenLocalFileAction")
             (openLocalFileAction as OpenLocalAction).myToolWindow = this
             val refreshAction = actionManager.getAction("RefreshAction")
             (refreshAction as RefreshAction).myToolWindow = this
             val actions = ArrayList<AnAction>()
+            actions.add(toggleRuleIdOrDescriptionAction)
             actions.add(openLocalFileAction)
             actions.add(refreshAction)
 
@@ -98,6 +102,8 @@ class SarifViewerWindowFactory : ToolWindowFactory {
         internal var currentBranch: GitLocalBranch? = null
 
         private var localMode = false
+        private lateinit var extractSarifFromFile: HashMap<String, MutableList<Leaf>>
+        private lateinit var selectedFile: File
         private val service = toolWindow.project.service<SarifService>()
         private val project = toolWindow.project
         private var main = ScrollPaneFactory.createScrollPane()
@@ -380,6 +386,13 @@ class SarifViewerWindowFactory : ToolWindowFactory {
             treeBuilding(map)
         }
 
+        fun toggleRuleIdOrDescription() {
+            if (localMode) {
+                currentView.ruleIdToggle = !currentView.ruleIdToggle
+                extractSarifFromFile = extractSarifFromFile(selectedFile)
+                treeBuilding(extractSarifFromFile)
+            }
+        }
         fun openLocalFile() {
             val fileChooser = JFileChooser()
             fileChooser.fileFilter = FileNameExtensionFilter("SARIF files", "sarif")
@@ -387,7 +400,7 @@ class SarifViewerWindowFactory : ToolWindowFactory {
                 val returnValue = fileChooser.showOpenDialog(null)
                 if (returnValue == JFileChooser.APPROVE_OPTION) {
                     val selectedFile: File = fileChooser.selectedFile
-                    val extractSarifFromFile = extractSarifFromFile(selectedFile)
+                    extractSarifFromFile = extractSarifFromFile(selectedFile)
                     treeBuilding(extractSarifFromFile)
                     localMode = true
                 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,8 @@
     <resource-bundle>messages.MyBundle</resource-bundle>
 
     <actions>
+        <action id="RuleIDorDescriptionAction" icon="AllIcons.Actions.Diff" class="com.github.adrienpessu.sarifviewer.actions.RuleIDorDescriptionAction" text="Toggle Rule ID or Description">
+        </action>
         <action id="OpenLocalFileAction" icon="AllIcons.Actions.MenuOpen" class="com.github.adrienpessu.sarifviewer.actions.OpenLocalAction" text="Open local SARIF file">
         </action>
         <action id="RefreshAction" icon="AllIcons.Actions.ForceRefresh" class="com.github.adrienpessu.sarifviewer.actions.RefreshAction" text="Refresh from GitHub">


### PR DESCRIPTION
Added a toggle Action Button to allow the user to switch the labelling of warnings in the plugin between RuleId or Description. This is useful for users who prefer to see the RuleId instead of the Description, or vice versa.